### PR TITLE
fix: use `encodeURIComponent` when save data to cookie

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -2,7 +2,7 @@ export const setCookie = (cname: string, cvalue: string, exdays: number) => {
     const d = new Date()
     d.setTime(d.getTime() + (exdays*24*60*60*1000))
     let expires = "expires="+ d.toUTCString()
-    document.cookie = cname + "=" + cvalue + ";" + expires + ";SameSite=Lax;path=/"
+    document.cookie = cname + "=" + encodeURIComponent(cvalue) + ";" + expires + ";SameSite=Lax;path=/"
 }
 
 export const getCookie = (cname: string): string => {


### PR DESCRIPTION
So basically what was happening is it was saving raw data in a cookie. like if a user has a password like `foo%bar` it would write it like that and when it tries to read it `decodeURIComponent` wouldn't be able to parse it. The solution is.... encode it first.